### PR TITLE
Capability to disable DinD dependencies and service toggle

### DIFF
--- a/pulsar/templates/NOTES.txt
+++ b/pulsar/templates/NOTES.txt
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled }}
 1. Get the application URL by running these commands:
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
@@ -5,7 +6,7 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
+{{- if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "pulsar.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
@@ -19,4 +20,11 @@
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+{{- end }}
+{{- else }}
+1. Pulsar is not exposed through the network.
+   This is expected in pull-based designs where Pulsar initiates outbound connections
+   to a message broker (e.g. AMQP/RabbitMQ).
+   No Service or Ingress resource has been created.
 {{- end }}

--- a/pulsar/templates/NOTES.txt
+++ b/pulsar/templates/NOTES.txt
@@ -6,7 +6,7 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
-{{- if contains "NodePort" .Values.service.type }}
+{{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "pulsar.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
@@ -20,7 +20,6 @@
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
-{{- end }}
 {{- end }}
 {{- else }}
 1. Pulsar is not exposed through the network.

--- a/pulsar/templates/deployment.yaml
+++ b/pulsar/templates/deployment.yaml
@@ -40,14 +40,18 @@ spec:
           env:
           - name: PULSAR_CONFIG_PRIVATE_TOKEN
             value: {{ .Values.api_key }}
+          {{- if .Values.service.enabled }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- end }}
+          {{- if .Values.service.enabled }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
@@ -72,10 +76,14 @@ spec:
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
+            {{- if .Values.dind.enabled }}
             - name: dind-storage
               mountPath: /var/lib/docker
             - name: dind-sock
               mountPath: /var/run
+            {{- end }}
+
+        {{- if .Values.dind.enabled }}
         - name: dind
           image: docker:dind
           env:
@@ -93,6 +101,7 @@ spec:
               mountPath: /var/lib/docker
             - name: dind-sock
               mountPath: /var/run
+        {{- end }}
       volumes:
         - name: pulsar-conf-files
           {{- if .Values.useSecretConfigs }}
@@ -109,10 +118,12 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- if .Values.dind.enabled }}
         - name: dind-storage
           emptyDir: {}
         - name: dind-sock
           emptyDir: {}
+        {{- end }}
         {{- if $.Values.refdata.enabled }}
         - name: pulsar-refdata
           persistentVolumeClaim:

--- a/pulsar/templates/ingress.yaml
+++ b/pulsar/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.enabled -}}
+{{- if and .Values.ingress.enabled .Values.service.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/pulsar/templates/service.yaml
+++ b/pulsar/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
       name: http
   selector:
     {{- include "pulsar.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/pulsar/templates/tests/test-connection.yaml
+++ b/pulsar/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -13,3 +14,4 @@ spec:
       command: ['wget']
       args: ['{{ include "pulsar.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never
+{{- end }}

--- a/pulsar/values.yaml
+++ b/pulsar/values.yaml
@@ -51,6 +51,7 @@ securityContext: {}
 
 # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
+  enabled: true
   # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   type: ClusterIP
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
@@ -97,7 +98,7 @@ readinessProbe:
 autoscaling:
   enabled: false
   minReplicas: 1
-  maxReplicas: 100
+  maxReplicas: 10
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
@@ -155,6 +156,10 @@ api_key: change_me_asap
 #- When this flag is set to true, all configs will be set in secrets,
 #- when it is set to false, all configs will be set in configmaps
 useSecretConfigs: false
+
+#- Block to enable or not DinD dependencies
+dind:
+  enabled: true
 
 #- All config files will be mapped into the `/pulsar/` directory
 configs:


### PR DESCRIPTION
## Goal

Enable Pulsar to run without Docker-in-Docker (DIND), making it compatible with external cloud providers and RabbitMQ-based deployments.

## Breaking changes

None, all changes are opt-in via values, default behavior unchanged.

## Validation
MD5 of generated template with default values matches upstream origin/main:
`f6fc75b869926e645647da1ba22fd5e1`

## Changes
- `service.enabled` toggle (default: `true`): disable HTTP port & ports lliveness/Readyness
- `dind.enabled` toggle (default: `false`) removes DIND sidecar, container, volumes and mounts when disabled
- `livenessProbe` / `readinessProbe`  when service is disabled
- `autoscaling.maxReplicas` reduced from 100 → 10
- `rbac.create` toggle for optional RBAC resources


